### PR TITLE
Fix a bug where phone numbers were listed as addresses

### DIFF
--- a/QSObject_ContactHandling.h
+++ b/QSObject_ContactHandling.h
@@ -13,11 +13,12 @@ NSString *formattedContactName(NSString *firstName, NSString *lastName, NSString
 @end
 
 @interface QSObject (ContactHandling)
-+ (id)objectWithPerson:(ABPerson *)person;
-//+ (id)objectWithString:(NSString *)string name:(NSString *)aName type:(NSString *)aType;
-//- (id)initWithString:(NSString *)string name:(NSString *)aName type:(NSString *)aType;
+
+- (QSObject *)initWithPerson:(ABPerson *)person;
++ (QSObject *)objectWithContactDetail:(NSString*)detail name:(NSString *)name type:(NSString *)type;
++ (QSObject *)objectWithPerson:(ABPerson *)person;
+
 - (ABPerson *)ABPerson;
-- (id)initWithPerson:(ABPerson *)person;
 - (void)loadContactInfo;
 - (void)loadContactInfo:(ABPerson *)person;
 


### PR DESCRIPTION
**Hopefully a quick one**

So... looks like nobody (me included!) checked the plugin before I released it ;-)
A copy/paste bug was introduced, which meant phone numbers were given the name "XXX address" instead of "XXX number". That's fixed in this pull, and I've also changed the way the contact info is displayed. It's all in the commit message
