### PR TITLE
Nicknames

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.2.1</string>
 	<key>CFBundleVersion</key>
-	<string>17B</string>
+	<string>17D</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2012, QSApp</string>
 	<key>QSActions</key>

--- a/QSAddressBookPlugIn.xcodeproj/project.pbxproj
+++ b/QSAddressBookPlugIn.xcodeproj/project.pbxproj
@@ -142,6 +142,8 @@
 /* Begin PBXProject section */
 		73FC13411545507500956087 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = 73FC13441545507500956087 /* Build configuration list for PBXProject "QSAddressBookPlugIn" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
@@ -219,7 +221,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 73FC135A1545507600956087 /* QSPlugIn.xcconfig */;
 			buildSettings = {
-				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
 		};
@@ -227,7 +228,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 73FC135A1545507600956087 /* QSPlugIn.xcconfig */;
 			buildSettings = {
-				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
 		};

--- a/QSObject_ContactHandling.h
+++ b/QSObject_ContactHandling.h
@@ -1,7 +1,4 @@
-
-#import <AddressBook/AddressBook.h>
-
-NSString *formattedContactName(NSString *firstName, NSString *lastName, NSString *middleName, NSString *suffix, NSString *prefix);
+@class ABPerson;
 
 @interface QSContactObjectHandler : NSObject
 + (NSArray *)URLObjectsForPerson:(ABPerson *)person asChild:(BOOL)asChild;

--- a/QSObject_ContactHandling.m
+++ b/QSObject_ContactHandling.m
@@ -309,21 +309,21 @@
 	NSString *firstName = [person valueForProperty:kABFirstNameProperty];
 	NSString *lastName = [person valueForProperty:kABLastNameProperty];
 	NSString *middleName = [person valueForProperty:kABMiddleNameProperty];
-//	NSString *nickName = [person valueForProperty:kABNicknameProperty];
+	NSString *nickName = [person valueForProperty:kABNicknameProperty];
   
 	NSString *title = [person valueForProperty:kABTitleProperty];
 	NSString *suffix = [person valueForProperty:kABSuffixProperty];
     NSString *jobTitle = [person valueForProperty:kABJobTitleProperty];
     NSString *companyName = [person valueForProperty:kABOrganizationProperty];
 
-	newLabel = formattedContactName(firstName, lastName, middleName, title, suffix);
-	newName = [person displayName];
-	
+    newName = [NSString stringWithFormat:@"%@ %@", nickName, lastName];
 	[self setName:newName];
     [self setObject:lastName forMeta:@"surname"];
-	
-	if (newLabel)
-		[self setLabel:newLabel];
+    
+    newLabel = [person displayName];
+    if (newLabel) {
+        [self setLabel:newLabel];
+    }
 	
 	[self setPrimaryType:QSABPersonType];
 	

--- a/QSObject_ContactHandling.m
+++ b/QSObject_ContactHandling.m
@@ -306,13 +306,13 @@
 	NSString *newName = nil;
 	NSString *newLabel = nil;
 	
-	NSString *firstName = [person valueForProperty:kABFirstNameProperty];
+    //NSString *firstName = [person valueForProperty:kABFirstNameProperty];
 	NSString *lastName = [person valueForProperty:kABLastNameProperty];
-	NSString *middleName = [person valueForProperty:kABMiddleNameProperty];
+    //NSString *middleName = [person valueForProperty:kABMiddleNameProperty];
 	NSString *nickName = [person valueForProperty:kABNicknameProperty];
   
-	NSString *title = [person valueForProperty:kABTitleProperty];
-	NSString *suffix = [person valueForProperty:kABSuffixProperty];
+    //NSString *title = [person valueForProperty:kABTitleProperty];
+    //NSString *suffix = [person valueForProperty:kABSuffixProperty];
     NSString *jobTitle = [person valueForProperty:kABJobTitleProperty];
     NSString *companyName = [person valueForProperty:kABOrganizationProperty];
 


### PR DESCRIPTION
I guess previous to 10.10, `-[ABPerson displayName]` would use the nickname. It seems to default to real name now. I played with settings in Contacts to see if I could change it that way, but it either doesn’t affect `displayName`, or the changes don’t take effect for a while. But I think we want Quicksilver to do what it always did regardless of new preferences.